### PR TITLE
feat(endpoint): add new async receive endpoint

### DIFF
--- a/spec/AsyncReceiveEndpoint-spec.ts
+++ b/spec/AsyncReceiveEndpoint-spec.ts
@@ -1,0 +1,132 @@
+import { defaultReceiveEndpointOptions, ReceiveEndpointOptions } from '../dist/receiveEndpoint';
+import { AsyncReceiveEndpoint } from '../dist/AsyncReceiveEndpoint';
+import { RabbitMqHostAddress } from '../src/RabbitMqEndpointAddress';
+import { Bus } from '../dist/bus';
+import { ConfirmChannel } from 'amqplib';
+import { ChannelContext } from '../dist/channelContext';
+import { MessageType } from '../dist/messageType';
+
+describe("AsyncReceiveEndpoint", () => {
+    let bus: jasmine.SpyObj<Bus>
+    let context: jasmine.SpyObj<ChannelContext>
+    let channel: jasmine.SpyObj<ConfirmChannel>
+
+    let receiveEndpoint: AsyncReceiveEndpoint
+
+    beforeEach(() => {
+        bus = jasmine.createSpyObj('Bus', ['on'], {
+            hostAddress: new RabbitMqHostAddress({ host: '', virtualHost: '' })
+        });
+        const connection = jasmine.createSpyObj('Connection', ['createConfirmChannel']);
+        channel = jasmine.createSpyObj('ConfirmChannel', [
+            'on',
+            'prefetch',
+            'consume',
+            'assertExchange',
+            'assertQueue',
+            'bindQueue',
+            'bindExchange'
+        ])
+        channel.assertQueue.and.returnValue({queue: '', messageCount: 0, consumerCount: 0} as any)
+        channel.consume.and.returnValue({ consumerTag: '' } as any)
+        context = jasmine.createSpyObj('ChannelContext', [], {
+            channel
+        })
+        connection.createConfirmChannel.and.returnValue(channel)
+    })
+
+    it("should configure default prefetch on connect", async () => {
+        createAsyncReceiveEndpoint()
+
+        await callOnChannel()
+
+        expect(channel.prefetch).toHaveBeenCalledWith(defaultReceiveEndpointOptions.prefetchCount, defaultReceiveEndpointOptions.globalPrefetch)
+    })
+
+    describe("should configure prefetch on connect", () => {
+        const testCases: [number, boolean][] = [
+            [1, false],
+            [1, true],
+            [5, true]
+        ]
+        for (const [prefetchCount, globalPrefetch] of testCases) {
+            it(`(${prefetchCount}, ${globalPrefetch})`, async () => {
+                const options = {
+                    ...defaultReceiveEndpointOptions,
+                    prefetchCount,
+                    globalPrefetch
+                }
+                createAsyncReceiveEndpoint('', options)
+
+                await callOnChannel()
+
+                expect(channel.prefetch).toHaveBeenCalledWith(prefetchCount, globalPrefetch)
+            })
+        }
+    })
+
+    describe("should assertExchange on connect", () => {
+        const testCases: string[] = ["queue name", "another queue"]
+        for (const queueName of testCases) {
+            it(`(${queueName})`, async () => {
+                createAsyncReceiveEndpoint(queueName)
+
+                await callOnChannel()
+
+                expect(channel.assertExchange).toHaveBeenCalledWith(queueName, 'fanout', defaultReceiveEndpointOptions)
+            })
+        }
+    })
+
+    describe("should assertQueue on connect", () => {
+        const testCases: string[] = ["queue name", "another queue"]
+        for (const queueName of testCases) {
+            it(`(${queueName})`, async () => {
+                createAsyncReceiveEndpoint(queueName)
+
+                await callOnChannel()
+
+                expect(channel.assertQueue).toHaveBeenCalledWith(queueName, defaultReceiveEndpointOptions)
+            })
+        }
+    })
+
+    describe("should bindQueue on connect", () => {
+        const testCases: string[] = ["queue name", "another queue"]
+        for (const queueName of testCases) {
+            it(`(${queueName})`, async () => {
+                createAsyncReceiveEndpoint(queueName)
+
+                await callOnChannel()
+
+                expect(channel.bindQueue).toHaveBeenCalledWith(queueName, queueName, '')
+            })
+        }
+    })
+
+    describe("should bind exchanges for every event bound via handle", () => {
+        const testCases: [string, MessageType][] = [
+            ["queue name", new MessageType("Event")],
+            ["another queue", new MessageType("Message", "Contract")]
+        ]
+        for (const [queueName, messageType] of testCases) {
+            it(`(${queueName})`, async () => {
+                createAsyncReceiveEndpoint(queueName)
+                receiveEndpoint.handle(messageType, jasmine.createSpy())
+
+                await callOnChannel()
+
+                expect(channel.bindExchange).toHaveBeenCalledWith(queueName, messageType.toExchange(), '')
+            })
+        }
+    })
+
+    async function callOnChannel(): Promise<void> {
+        // TODO: this is a hack so we can actually test the channel setup
+        await (receiveEndpoint as any).onChannel(context);
+    }
+
+    function createAsyncReceiveEndpoint(queueName: string = '', options?: ReceiveEndpointOptions) {
+        receiveEndpoint = new AsyncReceiveEndpoint(bus, queueName, undefined, options)
+    }
+})

--- a/spec/messageType-spec.ts
+++ b/spec/messageType-spec.ts
@@ -15,4 +15,16 @@ describe("messageType", () => {
 
         expect(messageType.toString()).toBe("urn:message:Contracts:SubmitOrder")
     })
+
+    it("toExchange should return namespace with name without protocol", () => {
+        const messageType = new MessageType("SubmitOrder")
+
+        expect(messageType.toExchange()).toBe("Messages:SubmitOrder")
+    })
+
+    it("toExchange should support custom namespace", () => {
+        const messageType = new MessageType("SubmitOrder", "Contracts")
+
+        expect(messageType.toExchange()).toBe("Contracts:SubmitOrder")
+    })
 })

--- a/spec/receiveEndpoint-spec.ts
+++ b/spec/receiveEndpoint-spec.ts
@@ -1,0 +1,131 @@
+import { defaultReceiveEndpointOptions, ReceiveEndpoint, ReceiveEndpointOptions } from '../dist/receiveEndpoint';
+import { RabbitMqHostAddress } from '../src/RabbitMqEndpointAddress';
+import { Bus } from '../dist/bus';
+import { ConfirmChannel } from 'amqplib';
+import { ChannelContext } from '../dist/channelContext';
+import { MessageType } from '../dist/messageType';
+
+describe("ReceiveEndpoint", () => {
+    let bus: jasmine.SpyObj<Bus>
+    let context: jasmine.SpyObj<ChannelContext>
+    let channel: jasmine.SpyObj<ConfirmChannel>
+
+    let receiveEndpoint: ReceiveEndpoint
+
+    beforeEach(() => {
+        bus = jasmine.createSpyObj('Bus', ['on'], {
+            hostAddress: new RabbitMqHostAddress({ host: '', virtualHost: '' })
+        });
+        const connection = jasmine.createSpyObj('Connection', ['createConfirmChannel']);
+        channel = jasmine.createSpyObj('ConfirmChannel', [
+            'on',
+            'prefetch',
+            'consume',
+            'assertExchange',
+            'assertQueue',
+            'bindQueue',
+            'bindExchange'
+        ])
+        channel.assertQueue.and.returnValue({queue: '', messageCount: 0, consumerCount: 0} as any)
+        channel.consume.and.returnValue({ consumerTag: '' } as any)
+        context = jasmine.createSpyObj('ChannelContext', [], {
+            channel
+        })
+        connection.createConfirmChannel.and.returnValue(channel)
+    })
+
+    it("should configure default prefetch on connect", async () => {
+        createReceiveEndpoint()
+
+        await callOnChannel()
+
+        expect(channel.prefetch).toHaveBeenCalledWith(defaultReceiveEndpointOptions.prefetchCount, defaultReceiveEndpointOptions.globalPrefetch)
+    })
+
+    describe("should configure prefetch on connect", () => {
+        const testCases: [number, boolean][] = [
+            [1, false],
+            [1, true],
+            [5, true]
+        ]
+        for (const [prefetchCount, globalPrefetch] of testCases) {
+            it(`(${prefetchCount}, ${globalPrefetch})`, async () => {
+                const options = {
+                    ...defaultReceiveEndpointOptions,
+                    prefetchCount,
+                    globalPrefetch
+                }
+                createReceiveEndpoint('', options)
+
+                await callOnChannel()
+
+                expect(channel.prefetch).toHaveBeenCalledWith(prefetchCount, globalPrefetch)
+            })
+        }
+    })
+
+    describe("should assertExchange on connect", () => {
+        const testCases: string[] = ["queue name", "another queue"]
+        for (const queueName of testCases) {
+            it(`(${queueName})`, async () => {
+                createReceiveEndpoint(queueName)
+
+                await callOnChannel()
+
+                expect(channel.assertExchange).toHaveBeenCalledWith(queueName, 'fanout', defaultReceiveEndpointOptions)
+            })
+        }
+    })
+
+    describe("should assertQueue on connect", () => {
+        const testCases: string[] = ["queue name", "another queue"]
+        for (const queueName of testCases) {
+            it(`(${queueName})`, async () => {
+                createReceiveEndpoint(queueName)
+
+                await callOnChannel()
+
+                expect(channel.assertQueue).toHaveBeenCalledWith(queueName, defaultReceiveEndpointOptions)
+            })
+        }
+    })
+
+    describe("should bindQueue on connect", () => {
+        const testCases: string[] = ["queue name", "another queue"]
+        for (const queueName of testCases) {
+            it(`(${queueName})`, async () => {
+                createReceiveEndpoint(queueName)
+
+                await callOnChannel()
+
+                expect(channel.bindQueue).toHaveBeenCalledWith(queueName, queueName, '')
+            })
+        }
+    })
+
+    describe("should bind exchanges for every event bound via handle", () => {
+        const testCases: [string, MessageType][] = [
+            ["queue name", new MessageType("Event")],
+            ["another queue", new MessageType("Message", "Contract")]
+        ]
+        for (const [queueName, messageType] of testCases) {
+            it(`(${queueName})`, async () => {
+                createReceiveEndpoint(queueName)
+                receiveEndpoint.handle(messageType, jasmine.createSpy())
+
+                await callOnChannel()
+
+                expect(channel.bindExchange).toHaveBeenCalledWith(queueName, messageType.toExchange(), '')
+            })
+        }
+    })
+
+    async function callOnChannel(): Promise<void> {
+        // TODO: this is a hack so we can actually test the channel setup
+        await (receiveEndpoint as any).onChannel(context);
+    }
+
+    function createReceiveEndpoint(queueName: string = '', options?: ReceiveEndpointOptions) {
+        receiveEndpoint = new ReceiveEndpoint(bus, queueName, undefined, options)
+    }
+})

--- a/spec/transport-spec.ts
+++ b/spec/transport-spec.ts
@@ -1,0 +1,84 @@
+import { Transport } from '../dist/transport';
+import { Bus } from '../dist/bus';
+import { ConnectionContext } from '../dist/connectionContext';
+import { ConfirmChannel } from 'amqplib';
+import { SendContext } from '../dist/sendContext';
+import { RabbitMqHostAddress } from '../src/RabbitMqEndpointAddress';
+
+describe("Transport", () => {
+    let bus: jasmine.SpyObj<Bus>
+    let context: jasmine.SpyObj<ConnectionContext>
+    let channel: jasmine.SpyObj<ConfirmChannel>
+
+    let transport: Transport
+
+    beforeEach(() => {
+        bus = jasmine.createSpyObj('Bus', ['on'], {
+            hostAddress: new RabbitMqHostAddress({ host: '', virtualHost: '' })
+        });
+        const connection = jasmine.createSpyObj('Connection', ['createConfirmChannel']);
+        context = jasmine.createSpyObj('ConnectionContext', [], {
+            connection
+        })
+        channel = jasmine.createSpyObj('ConfirmChannel', ['publish', 'on'])
+        connection.createConfirmChannel.and.returnValue(channel)
+
+        transport = new Transport(bus)
+    })
+
+    describe("send should publish the given message", () => {
+        const testCases = [
+            ['exchange', 'routingKey'],
+            ['MessageExchange', 'RoutingKey']
+        ]
+        for (const [exchange, routingKey] of testCases) {
+            it(`(${exchange}, ${routingKey})`, async () => {
+                callPublishCallback()
+                await callOnConnect()
+
+                await transport.send(exchange, routingKey, new SendContext({}))
+
+                expect(channel.publish).toHaveBeenCalledWith(exchange, routingKey, jasmine.any(Buffer), jasmine.any(Object), jasmine.any(Function))
+            })
+        }
+    })
+
+    it("send should set the contentType", async () => {
+        callPublishCallback()
+        await callOnConnect()
+
+        await transport.send('', '', new SendContext({}))
+
+        expect(channel.publish).toHaveBeenCalledWith(jasmine.any(String), jasmine.any(String), jasmine.any(Buffer), {
+            persistent: true,
+            contentType: "application/vnd.masstransit+json"
+        }, jasmine.any(Function))
+    })
+
+    it("publishing after onConnect should set the contentType", async () => {
+        callPublishCallback()
+        transport.send('', '', new SendContext({}))
+
+        await callOnConnect()
+
+        expect(channel.publish).toHaveBeenCalledWith(jasmine.any(String), jasmine.any(String), jasmine.any(Buffer), {
+            persistent: true,
+            contentType: "application/vnd.masstransit+json"
+        }, jasmine.any(Function))
+    })
+
+    function callPublishCallback() {
+        channel.publish.and.callFake((exchange, routingKey, content, options, callback) => {
+            if (callback != null) {
+                callback(null, {});
+            }
+            return true;
+        })
+    }
+
+    function callOnConnect() {
+        const callback = bus.on.calls.first().args[1];
+
+        return callback(context);
+    }
+})

--- a/src/AsyncReceiveEndpoint.ts
+++ b/src/AsyncReceiveEndpoint.ts
@@ -1,0 +1,148 @@
+import {ConfirmChannel, ConsumeMessage} from 'amqplib';
+import {Bus} from './bus';
+import {deserialize} from 'class-transformer';
+import {ConsumeContext} from './consumeContext';
+import {MessageContext} from './messageContext';
+import {MessageMap} from './serialization';
+import {SendEndpointArguments, Transport} from './transport';
+import {ChannelContext} from './channelContext';
+import {MessageType} from './messageType';
+import {EndpointSettings, RabbitMqEndpointAddress, RabbitMqHostAddress} from './RabbitMqEndpointAddress';
+import {SendEndpoint} from './sendEndpoint';
+import {defaultReceiveEndpointOptions, ReceiveEndpointOptions} from './receiveEndpoint';
+
+/**
+ * Configure the receive endpoint, including any message handlers
+ */
+export interface AsyncReceiveEndpointConfigurator {
+    queueName: string
+    options: ReceiveEndpointOptions
+
+    handle<T extends MessageMap>(messageType: MessageType, listener: (message: ConsumeContext<T>) => Promise<void>): this
+}
+
+export interface AsyncReceiveEndpoint {
+    hostAddress: RabbitMqHostAddress
+    address: RabbitMqEndpointAddress
+
+    sendEndpoint(args: SendEndpointArguments): SendEndpoint
+}
+
+export class AsyncReceiveEndpoint extends Transport implements AsyncReceiveEndpointConfigurator, AsyncReceiveEndpoint {
+    queueName: string;
+    options: ReceiveEndpointOptions;
+
+    handle<T extends Record<string, any>>(messageType: MessageType, listener: (message: ConsumeContext<T>) => Promise<void>): this {
+
+        if (!messageType)
+            throw new Error(`Invalid argument: messageType`);
+
+        let typeName = messageType.toString();
+
+        if (this._messageTypes.hasOwnProperty(typeName)) {
+            this._messageTypes[typeName].on(listener);
+        } else {
+            const deserializer = new AsyncMessageTypeDeserializer<T>(this, listener);
+            this._messageTypes[typeName] = deserializer;
+            this.boundEvents.push(messageType);
+        }
+
+        return this;
+    }
+
+    private readonly _messageTypes: MessageMap;
+    private readonly boundEvents: MessageType[] = [];
+
+    constructor(bus: Bus, queueName: string, cb?: (cfg: AsyncReceiveEndpointConfigurator) => void, options: ReceiveEndpointOptions = defaultReceiveEndpointOptions) {
+        super(bus);
+
+        this.queueName = queueName;
+        this.options = options;
+        this.hostAddress = bus.hostAddress;
+        this._messageTypes = {};
+
+        if (cb) cb(this);
+
+        let settings: EndpointSettings = {name: queueName, ...options};
+
+        this.address = new RabbitMqEndpointAddress(bus.hostAddress, settings);
+
+        this.on('channel', (context) => this.onChannel(context));
+    }
+
+    emitMessage(msg: ConsumeMessage): void {
+        this.emit('message', msg);
+    }
+
+    private async onChannel(context: ChannelContext): Promise<void> {
+        const _this = this;
+
+        let channel = context.channel;
+
+        await this.configureTopology(channel);
+
+        let consume = await channel.consume(this.queueName, async (msg: ConsumeMessage | null) => {
+            if (msg === null) return;
+
+            try {
+                _this.emit('message', msg);
+
+                let text = msg.content.toString();
+
+                let context = deserialize(MessageContext, text);
+
+                if (context && context.messageType && context.messageType.length > 0) {
+
+                    let messageType = context.messageType[0];
+
+                    let deserializer = this._messageTypes[messageType];
+                    if (deserializer instanceof AsyncMessageTypeDeserializer) {
+                        await deserializer.handle(text);
+                    }
+                }
+
+                channel.ack(msg);
+            } catch (e) {
+                channel.reject(msg, true);
+            }
+        }, this.options);
+
+        this.options.consumerTag = consume.consumerTag;
+
+        console.log('Receive endpoint started:', this.queueName, 'ConsumerTag:', consume.consumerTag);
+    }
+
+    private async configureTopology(channel: ConfirmChannel) {
+        await channel.prefetch(this.options.prefetchCount, this.options.globalPrefetch);
+
+        await channel.assertExchange(this.queueName, 'fanout', this.options);
+        let queue = await channel.assertQueue(this.queueName, this.options);
+
+        await channel.bindQueue(this.queueName, this.queueName, '');
+
+        for (const messageType of this.boundEvents) {
+            await channel.bindExchange(this.queueName, messageType.toExchange(), '');
+        }
+
+        console.log('Queue:', queue.queue, 'MessageCount:', queue.messageCount, 'ConsumerCount:', queue.consumerCount);
+    }
+}
+
+export class AsyncMessageTypeDeserializer<T extends MessageMap> {
+    private readonly receiveEndpoint: AsyncReceiveEndpoint;
+    private readonly handler: (context: ConsumeContext<T>) => Promise<void>;
+
+    constructor(receiveEndpoint: AsyncReceiveEndpoint, handler: (context: ConsumeContext<T>) => Promise<void>) {
+        this.receiveEndpoint = receiveEndpoint;
+        this.handler = handler;
+    }
+
+    handle(json: string): Promise<void> {
+
+        let context = <ConsumeContext<T>>deserialize(ConsumeContext, json);
+
+        context.receiveEndpoint = this.receiveEndpoint;
+
+        return this.handler(context)
+    }
+}

--- a/src/bus.ts
+++ b/src/bus.ts
@@ -84,7 +84,7 @@ class MassTransitBus extends EventEmitter implements Bus {
 
             console.log('Bus stopped', this.hostAddress.toString());
         }
-        catch (e) {
+        catch (e: any) {
             console.error('failed to close bus', e.message);
         }
     }
@@ -135,7 +135,7 @@ class MassTransitBus extends EventEmitter implements Bus {
         console.log('Connecting', this.hostAddress.toString());
 
         try {
-            this.connection = connect(this.hostAddress + '?heartbeat=60');
+            this.connection = connect(this.hostAddress + '?heartbeat=60') as unknown as Promise<Connection>;
 
             let connection = await this.connection;
 
@@ -154,7 +154,7 @@ class MassTransitBus extends EventEmitter implements Bus {
 
             this.emit('connect', {hostAddress: this.hostAddress, connection: connection});
         }
-        catch (e) {
+        catch (e: any) {
             console.error('Connect failed', e.message);
 
             this.scheduleReconnect();

--- a/src/bus.ts
+++ b/src/bus.ts
@@ -10,6 +10,7 @@ import {MessageMap} from './serialization';
 import {RequestClient} from './requestClient';
 import {MessageType} from './messageType';
 import {HostSettings, RabbitMqHostAddress} from './RabbitMqEndpointAddress';
+import {AsyncReceiveEndpoint, AsyncReceiveEndpointConfigurator} from './AsyncReceiveEndpoint';
 
 export interface Bus {
     hostAddress: RabbitMqHostAddress
@@ -21,6 +22,7 @@ export interface Bus {
     on(event: 'error', listener: (err: any) => void): this
 
     receiveEndpoint(queueName: string, config: (endpoint: ReceiveEndpointConfigurator) => void, options?: ReceiveEndpointOptions): void
+    asyncReceiveEndpoint(queueName: string, config: (endpoint: AsyncReceiveEndpointConfigurator) => void, options?: ReceiveEndpointOptions): void
 
     sendEndpoint(args: SendEndpointArguments): SendEndpoint
 
@@ -49,6 +51,28 @@ class MassTransitBus extends EventEmitter implements Bus {
     receiveEndpoint(queueName: string, cb?: (cfg: ReceiveEndpointConfigurator) => void, options: ReceiveEndpointOptions = defaultReceiveEndpointOptions): ReceiveEndpoint {
 
         let endpoint = new ReceiveEndpoint(this, queueName, cb, {...defaultReceiveEndpointOptions, ...options});
+
+        this.connection?.then(connection => endpoint.onConnect({hostAddress: this.hostAddress, connection: connection}));
+
+        return endpoint;
+    }
+
+    /**
+     * Connects a receive endpoint to the bus
+     * This endpoint waits for a promise to resolve before acknowledging received messages.
+     *
+     * @remarks
+     * Once connected, the receive endpoint will remain connected until disconnected
+     *
+     * @param queueName - The input queue name
+     * @param cb - The configuration callback, used to add message handlers, etc.
+     * @param options - Options for the receive endpoint, such as queue/exchange properties, etc.
+     * @returns Nothing yet, but should return the receive endpoint so that it can be stopped
+     *
+     */
+    asyncReceiveEndpoint(queueName: string, cb?: (cfg: AsyncReceiveEndpointConfigurator) => void, options: ReceiveEndpointOptions = defaultReceiveEndpointOptions): AsyncReceiveEndpoint {
+
+        let endpoint = new AsyncReceiveEndpoint(this, queueName, cb, {...defaultReceiveEndpointOptions, ...options});
 
         this.connection?.then(connection => endpoint.onConnect({hostAddress: this.hostAddress, connection: connection}));
 

--- a/src/consumeContext.ts
+++ b/src/consumeContext.ts
@@ -4,6 +4,7 @@ import {MessageMap} from './serialization';
 import {SendContext} from './sendContext';
 import {ReceiveEndpoint} from './receiveEndpoint';
 import {RabbitMqEndpointAddress} from './RabbitMqEndpointAddress';
+import {AsyncReceiveEndpoint} from './AsyncReceiveEndpoint';
 
 export interface ConsumeContext<T extends object> extends MessageContext {
     message: T;
@@ -42,7 +43,7 @@ export class ConsumeContext<T extends object> implements ConsumeContext<T> {
 
     }
 
-    receiveEndpoint!: ReceiveEndpoint;
+    receiveEndpoint!: ReceiveEndpoint | AsyncReceiveEndpoint;
 }
 
 

--- a/src/messageType.ts
+++ b/src/messageType.ts
@@ -19,5 +19,9 @@ export class MessageType {
     toMessageType(): Array<string> {
         return [this.toString()];
     }
+
+    toExchange(): string {
+        return `${this.ns}:${this.name}`
+    }
 }
 

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -116,6 +116,7 @@ export class Transport extends EventEmitter implements Transport {
             let pendingPublish = this.pendingPublishQueue.shift();
             if (!pendingPublish) break;
 
+            // TODO: resolve or reject pending publishes
             let {exchange, message, routingKey} = pendingPublish;
 
             await this.basicPublish(exchange, routingKey, message);

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -127,7 +127,7 @@ export class Transport extends EventEmitter implements Transport {
         if (this.channel) {
             let channel = this.channel;
             return new Promise((resolve, reject) => {
-                const result = channel.publish(exchange, routingKey, body, {persistent: true},
+                const result = channel.publish(exchange, routingKey, body, {persistent: true, contentType: "application/vnd.masstransit+json"},
                     err => {
                         if (err) {
                             reject(err);


### PR DESCRIPTION
This fixes an issue where the handling of a message will not impact the acknowledgment of the message.
The AsyncReceiveEndpoint waits for the message handler to resolve before acknowledging the message or it noAcks the message when the handler throws.
To not cause breaking changes I've implemented this as a second implementation of the receive endpoint.

I've also incorporated the improvements I've made in #6, so this should probably be merged after #6 so I can remove the unrelated commits from this branch.